### PR TITLE
chore: improve .gitignore for Python virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 *.pyd
 .Python
 env/
+.venv/
+venv/
 pip-log.txt
 pip-delete-this-directory.txt
 .tox/


### PR DESCRIPTION
## Summary
- Added `.venv/` to .gitignore to exclude uv-created virtual environments
- Added `venv/` as an alternative virtual environment directory name
- Ensures clean git status when using modern Python tooling (uv, pip, etc.)

## Changes
- Updated `.gitignore` with virtual environment directories

## Test plan
- [x] Verified git status is clean after creating .venv
- [x] Pre-commit hooks pass successfully
- [x] No virtual environment files are tracked by git

## Why this matters
Modern Python tools like `uv` create `.venv` directories by default. Without this in .gitignore, these directories could accidentally be committed, polluting the repository with thousands of dependency files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)